### PR TITLE
fixed the path to which the model and input files are pushed to on the android device

### DIFF
--- a/scripts/adb_push.sh
+++ b/scripts/adb_push.sh
@@ -12,8 +12,8 @@ LOCAL_INPUTS="$SOURCE_DIR/inputs"
 
 REMOTE_BIN_DIR="/data/local/tmp/bin"
 REMOTE_LIB_DIR="/data/local/tmp/lib"
-REMOTE_MODELS_DIR="/sdcard/tflite/models"
-REMOTE_INPUTS_DIR="/sdcard/tflite/inputs"
+REMOTE_MODELS_DIR="/sdcard/argmax/tflite/models"
+REMOTE_INPUTS_DIR="/sdcard/argmax/tflite/inputs"
 
 # Function to push files only if they do not exist
 push_if_not_exists() {


### PR DESCRIPTION
- adb_push.sh pushes the model and input audio files to /sdcard/tflite/models and /sdcard/tflite/inputs. but axie_tflite looks for the model files under /sdcard/argmax/tflite/models
- updated the path in the adb_push.sh to push the models to the correct directory