### PR TITLE
Add whisperkit-cli with options parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(${ANDROID})
       ${AXIE_SRC_DIR}/post_proc.cpp
       ${AXIE_SRC_DIR}/audio_input.cpp
       ${AXIE_SRC_DIR}/whisperax.cpp
-    )  
+    )
   else() # generic TFLite GPU delegate
     message(NOTICE  " Delegate via Generic TFLite GPU..")
     add_library(whisperax   SHARED
@@ -76,24 +76,24 @@ target_include_directories(whisperax PRIVATE
 
 if(${ANDROID})
 
-  if(${QNN_DELEGATE}) 
+  if(${QNN_DELEGATE})
     ADD_DEFINITIONS(-DQNN_DELEGATE)
     add_library(qnn_delegate SHARED IMPORTED)
-    set_property(TARGET qnn_delegate PROPERTY IMPORTED_LOCATION 
+    set_property(TARGET qnn_delegate PROPERTY IMPORTED_LOCATION
       ${EXT_LIB_DIR}/libQnnTFLiteDelegate.so
     )
-    target_link_libraries(whisperax PRIVATE 
-      qnn_delegate 
-      tensorflowlite 
+    target_link_libraries(whisperax PRIVATE
+      qnn_delegate
+      tensorflowlite
       tensorflowlite_gpu_delegate
       ${android_log}
       SDL3
     )
 
-  else() 
+  else()
     ADD_DEFINITIONS(-DGPU_DELEGATE)
-    target_link_libraries(whisperax PRIVATE 
-      tensorflowlite 
+    target_link_libraries(whisperax PRIVATE
+      tensorflowlite
       tensorflowlite_gpu_delegate
       ${android_log}
       SDL3
@@ -101,8 +101,8 @@ if(${ANDROID})
   endif()
 
 else()
-  target_link_libraries(whisperax PRIVATE 
-    tensorflowlite 
+  target_link_libraries(whisperax PRIVATE
+    tensorflowlite
     SDL3
   )
 endif()
@@ -120,13 +120,33 @@ add_executable(whisperax_cli
   ${AXIE_CLI_DIR}/audio_codec.cpp
 )
 
+add_executable(whisperkit-cli
+    ${AXIE_CLI_DIR}/whisperkit_cli.cpp
+    ${AXIE_CLI_DIR}/audio_codec.cpp
+)
+
 target_include_directories(whisperax_cli PRIVATE
   ${AXIE_INC_DIR}
   ${AXIE_CLI_DIR}
   ${EXT_INC_DIR}
 )
 
-target_link_libraries(whisperax_cli PRIVATE 
+target_include_directories(whisperkit-cli PRIVATE
+  ${AXIE_INC_DIR}
+  ${AXIE_CLI_DIR}
+  ${AXIE_SRC_DIR}/external/
+  ${EXT_INC_DIR}
+)
+
+target_link_libraries(whisperax_cli PRIVATE
+  whisperax
+  avformat
+  avcodec
+  avutil
+  swresample
+)
+
+target_link_libraries(whisperkit-cli PRIVATE
   whisperax
   avformat
   avcodec
@@ -135,5 +155,9 @@ target_link_libraries(whisperax_cli PRIVATE
 )
 
 target_compile_definitions(whisperax_cli PRIVATE
+  "-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\""
+)
+
+target_compile_definitions(whisperkit-cli PRIVATE
   "-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\""
 )

--- a/cli/whisperkit_cli.cpp
+++ b/cli/whisperkit_cli.cpp
@@ -1,0 +1,162 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2024 Argmax, Inc. All rights reserved.
+
+#include <iostream>
+#include "cxxopts.hpp"
+
+
+struct WhisperKitConfig {
+
+public:
+    std::string audioPath;
+    std::string modelPath;
+    std::string audioEncoderComputeUnits;
+    std::string textDecoderComputeUnits;
+    float temperature;
+    float temperatureIncrementOnFallback;
+    int temperatureFallbackCount;
+    int bestOf;
+    bool skipSpecialTokens;
+    bool withoutTimestamps;
+    bool wordTimestamps;
+    float logprobThreshold;
+    float firstTokenLogProbThreshold;
+    float noSpeechThreshold;
+    bool report;
+    std::string reportPath;
+    int concurrentWorkerCount;
+
+    WhisperKitConfig()  {
+        audioPath = "";
+        modelPath = "";
+        audioEncoderComputeUnits = "";
+        textDecoderComputeUnits = "";
+        temperature = 0.f;
+        temperatureIncrementOnFallback = 0.2f;
+        temperatureFallbackCount = 5;
+        bestOf = 5;
+        skipSpecialTokens = false;
+        withoutTimestamps = false;
+        wordTimestamps = false;
+        logprobThreshold = -1.f;
+        firstTokenLogProbThreshold = -1.f;
+        noSpeechThreshold = 0.3f;
+        report = false;
+        reportPath = ".";
+        concurrentWorkerCount = 4;
+    };
+
+    // Delete assignment, copy ctor
+    WhisperKitConfig& operator=(const WhisperKitConfig&) = delete;
+    WhisperKitConfig(const WhisperKitConfig&) = delete;
+
+};
+
+
+int main(int argc, char* argv[]) {
+    try {
+        cxxopts::Options options("whisperkit-cli", "WhisperKit CLI for Android & Linux");
+
+        options.add_options("transcribe")
+            ("h,help", "Print help")
+            ("audio-path", "Path to audio file", cxxopts::value<std::string>())
+            ("model-path", "Path of model files", cxxopts::value<std::string>())
+            ("audio-encoder-compute-units", "Compute units for audio encoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine}", cxxopts::value<std::string>())
+            ("text-decoder-compute-units", "Compute units for text decoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}", cxxopts::value<std::string>())
+            ("temperature", "Temperature to use for sampling", cxxopts::value<float>()->default_value("0.0"))
+            ("temperature-increment-on-fallback", "Temperature to increase on fallbacks during decoding", cxxopts::value<float>()->default_value("0.2"))
+            ("temperature-fallback-count", "Number of times to increase temperature when falling back during decoding", cxxopts::value<int>()->default_value("5"))
+            ("best-of", "Number of candidates when sampling with non-zero temperature", cxxopts::value<int>()->default_value("5"))
+            ("skip-special-tokens", "Skip special tokens in the output", cxxopts::value<bool>()->default_value("false"))
+            ("without-timestamps", "Force no timestamps when decoding", cxxopts::value<bool>()->default_value("false"))
+            ("word-timestamps", "Add timestamps for each word in the output", cxxopts::value<bool>()->default_value("false"))
+            ("logprob-threshold", "Average log probability threshold for decoding failure", cxxopts::value<float>()->default_value("-1.0")) // TODO: check
+            ("first-token-log-prob-threshold", "Log probability threshold for first token decoding failure", cxxopts::value<float>()->default_value("-1.0"))
+            ("no-speech-threshold",  "Probability threshold to consider a segment as silence", cxxopts::value<float>()->default_value("-1.0"))
+            ("report","Output a report of the results", cxxopts::value<bool>()->default_value("false"))
+            ("report-path", "Directory to save the report", cxxopts::value<std::string>()->default_value("."))
+            ("concurrent-worker-count", "Maximum concurrent inference, might be helpful when processing more than 1 audio file at the same time. 0 means unlimited. Default: 4", cxxopts::value<int>()->default_value("4"))
+            ("v,verbose", "Verbose mode for debug", cxxopts::value<bool>()->default_value("false"));
+
+        auto result = options.parse(argc, argv);
+
+        if (result.count("help")) {
+            std::cout << options.help() << std::endl;
+            return 0;
+        }
+        
+        WhisperKitConfig config;
+
+        if (result.count("audio-path")) {
+            config.audioPath = result["audio-path"].as<std::string>();
+        }
+
+        if (result.count("model-path")) {
+            config.modelPath = result["model-path"].as<std::string>();
+        }
+        if (result.count("audio-encoder-compute-units")) {
+            config.audioEncoderComputeUnits = result["audio-encoder-compute-units"].as<std::string>();
+        }
+        if (result.count("text-decoder-compute-units")) {
+            config.textDecoderComputeUnits = result["text-decoder-compute-units"].as<std::string>();
+        }
+        if (result.count("temperature")) {
+            config.temperature = result["temperature"].as<float>();
+        }
+        if (result.count("temperature-increment-on-fallback")) {
+            config.temperatureIncrementOnFallback = result["temperature-increment-on-fallback"].as<float>();
+        }
+    
+        if (result.count("temperature-fallback-count")) {
+            config.temperatureFallbackCount = result["temperature-fallback-count"].as<int>();
+        }
+        if (result.count("best-of")) {
+            config.bestOf = result["best-of"].as<int>();
+        }
+        if (result.count("skip-special-tokens")) {
+            config.skipSpecialTokens = result["skip-special-tokens"].as<bool>();
+        }
+        if (result.count("without-timestamps")) {
+            config.withoutTimestamps = result["without-timestamps"].as<bool>();
+        }
+        if (result.count("word-timestamps")) {
+            config.wordTimestamps = result["word-timestamps"].as<bool>();
+        }
+        if (result.count("logprob-threshold")) {
+            config.logprobThreshold = result["logprob-threshold"].as<float>();
+        }
+        if (result.count("first-token-log-prob-threshold")) {
+            config.firstTokenLogProbThreshold = result["first-token-log-prob-threshold"].as<float>();
+        }
+        if (result.count("no-speech-threshold")) {
+            config.noSpeechThreshold = result["no-speech-threshold"].as<float>();
+        }
+        if (result.count("report")) {
+            config.report = result["report"].as<bool>();
+        }
+        if (result.count("report-path")) {
+            config.reportPath = result["report-path"].as<std::string>();
+        }
+        if (result.count("concurrent-worker-count")) {
+            config.concurrentWorkerCount = result["concurrent-worker-count"].as<int>();
+        }
+        if (result["verbose"].as<bool>()) {
+            std::cout << "Verbose mode is ON." << std::endl;
+        }
+        
+
+    } catch (const cxxopts::exceptions::exception& e) {
+        std::cerr << "Error parsing options: " << e.what() << std::endl;
+        return 1;
+    }
+
+    // adding stubs for interface and parsing the options; fail loudly while not yet implemented
+    if (1) {
+        std::cerr << "whisperkit-cli: not yet implemented; use whisperax_cli for transcription " << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
+
+


### PR DESCRIPTION
Note that the cli is not yet implemented: this is options parsing and the matching options syntax as from whisperkit-cli.  It prints out the help message, and otherwise fails with instructions to use whisperax_cli until whisperkit-cli is implemented [followup change]