### PR TITLE
Part 1 of in-memory models: VAD model built in memory.

### DIFF
--- a/WhisperKit/src/Audio/audio_input.hpp
+++ b/WhisperKit/src/Audio/audio_input.hpp
@@ -50,7 +50,7 @@ public:
     short int* get_buffer() { return _buffer; }
 };
 
-class AudioInputModel: public MODEL_SUPER_CLASS {
+class AudioInputModel {
 public:
     AudioInputModel(int freq, int channels, int format = SAMPLE_FMT_DEF);
     virtual ~AudioInputModel() {};
@@ -64,6 +64,10 @@ public:
     void uninitialize();
     virtual void invoke(bool measure_time=false);
 
+    // this is temporary
+    std::vector<std::pair<char*, int>> get_input_ptrs();
+    std::vector<std::pair<char*, int>> get_output_ptrs();
+
     void fill_pcmdata(int size, char* pcm_buffer=nullptr);
     float get_next_chunk(char* output);
     int get_curr_buf_time() { return _curr_buf_time; }
@@ -74,6 +78,8 @@ public:
 
 private:
     SDL_AudioStream* _stream = nullptr;
+
+    std::unique_ptr<TFLiteModel> _model;
 
     int32_t _total_src_bytes = 0;
     int32_t _buffer_index = 0;

--- a/WhisperKit/src/Models/tflite_model.hpp
+++ b/WhisperKit/src/Models/tflite_model.hpp
@@ -29,6 +29,16 @@
 
 using json = nlohmann::json;
 
+namespace WhisperKit {
+    namespace InMemoryModel {
+        enum class ModelType {
+            kSimpleVADModel = 1,
+            kSimplePostProcessingModel = 2
+        };
+    }
+}
+
+
 class TFLiteModel {
 public:
     TFLiteModel(const std::string& name);
@@ -41,6 +51,12 @@ public:
         int backend, 
         bool debug=false
     );
+
+    bool initializeModelInMemory(
+        WhisperKit::InMemoryModel::ModelType model_type,
+        bool debug=false
+    );
+
     void uninitialize();
     virtual void invoke(bool measure_time=false);
 
@@ -59,6 +75,8 @@ public:
 
     static void save_tensor(std::string filename, char* tensor, int size);
 
+    std::vector<float> _latencies;
+
 protected: 
     std::mutex _mutex;
     std::unique_ptr<tflite::FlatBufferModel> _model;
@@ -68,7 +86,6 @@ protected:
     std::string _lib_dir; 
     std::string _cache_dir; 
     std::string _model_token;
-    std::vector<float> _latencies;
 
     std::vector<std::pair<char*, int>> _input_ptrs;
     std::vector<std::pair<char*, int>> _output_ptrs;    
@@ -77,4 +94,8 @@ protected:
     bool allocate_tensors();
     void modify_graph_delegate();
     void set_dirs(std::string filename, std::string lib_dir, std::string cache_dir);
+
+
+    private:
+        bool buildSimpleVADModel();
 };


### PR DESCRIPTION
Not yet enabled in the execution pathway

## Description  
This PR is the first step towards deleting excess model resources and allowing configurable sampling at pre- and post-procesing for the WhisperKit pipeline.  Here, we target the 'voice_activity_detection.tflite' model, which is a simple RMSE less bias for threshold to determine voice activity in a given frame.

Separately, place VAD always on CPU.

## Type of Change  
- [ ] Bug fix 🐛  
- [x] New feature 🚀  
- [ ] Refactor 🔄  
- [ ] Documentation update 📖  
- [ ] Other (please describe)  

## Test Plan  
- [x] I have run `bash test/test_build_all.sh` and it ran successfully
- [x] I have tested this change on all relevant platforms.  
