### PR TITLE
Transition audio input (VAD) implementation to use in-memory construction model

### DIFF
--- a/WhisperKit/src/Audio/audio_input.cpp
+++ b/WhisperKit/src/Audio/audio_input.cpp
@@ -153,10 +153,6 @@ AudioInputModel::AudioInputModel( // buffer input mode
 }
 
 bool AudioInputModel::initialize(
-    string model_file,
-    string lib_dir,
-    string cache_dir, 
-    int backend, 
     bool debug
 ){
     SDL_SetMainReady();
@@ -165,7 +161,7 @@ bool AudioInputModel::initialize(
         return false;
     }
 
-    if(!_model->initialize(model_file, lib_dir, cache_dir, backend, debug)){
+    if(!_model->initializeModelInMemory(WhisperKit::InMemoryModel::ModelType::kSimpleVADModel, debug)){
         LOGE("Failed to initialize\n");
         return false;
     }

--- a/WhisperKit/src/Audio/audio_input.hpp
+++ b/WhisperKit/src/Audio/audio_input.hpp
@@ -56,10 +56,6 @@ public:
     virtual ~AudioInputModel() {};
 
     bool initialize(
-        std::string model_path, 
-        std::string lib_dir,
-        std::string cache_dir, 
-        int backend, 
         bool debug=false);
     void uninitialize();
     virtual void invoke(bool measure_time=false);

--- a/WhisperKit/src/Models/tflite_model.hpp
+++ b/WhisperKit/src/Models/tflite_model.hpp
@@ -81,6 +81,7 @@ protected:
     std::mutex _mutex;
     std::unique_ptr<tflite::FlatBufferModel> _model;
     std::unique_ptr<tflite::Interpreter> _interpreter;
+    flatbuffers::FlatBufferBuilder _builder;
     TfLiteDelegate* _delegate = nullptr;
     std::string _model_name;
     std::string _lib_dir; 

--- a/WhisperKit/src/TranscribeTask.cpp
+++ b/WhisperKit/src/TranscribeTask.cpp
@@ -308,11 +308,7 @@ void Runtime::tflite_init_audioinput(const AudioCodec* audio_codec, const char* 
     const int fmt = audio_codec->get_format(); 
     audioinput = make_unique<AudioInputModel>(freq, channels, fmt);
 
-    std::string audio_model =  config.get_model_path() +  "/voice_activity_detection.tflite";
-
-    TFLITE_INIT_CHECK(audioinput->initialize(
-        audio_model, lib_dir, cache_dir, backend, debug
-    ));
+    TFLITE_INIT_CHECK(audioinput->initialize(debug));
 
     start_exec = chrono::high_resolution_clock::now();
 


### PR DESCRIPTION

## Description  
* Fixes bug in VAD in-memory model implementation
* Changes AudioInputModel::initialize to use initializeModelInMemory() instead of loading from file
* Removes unused directory paths and backend type from function signatures

## Type of Change  
- [x] Bug fix 🐛  
- [x] New feature 🚀  
- [ ] Refactor 🔄  
- [ ] Documentation update 📖  
- [ ] Other (please describe)  

## Test Plan  
- [x] I have run `bash test/test_build_all.sh` and it ran successfully
- [] I have tested this change on all relevant platforms.  

## Checklist  
- [x] My code follows the project's style guidelines.  
- [x] I have updated relevant documentation (if applicable).  
- [x] I have added appropriate tests (if applicable).  
- [x] I have self-reviewed my code before requesting review.  
