### PR TITLE
Add git precommit hook and github actions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,7 +10,7 @@ if [ -n "$KT_FILES" ]; then
     echo "Running spotlessKotlinCheck..."
     ./gradlew spotlessKotlinCheck
     if [ $? -ne 0 ]; then
-        echo "❌ Kotlin files need formatting. Please run './gradlew spotlessKotlinApply' and commit again."
+        echo "❌ Kotlin files need formatting. Please run './gradlew spotlessKotlinApply' or 'make format' and commit again."
         exit 1
     fi
 fi
@@ -19,7 +19,7 @@ if [ -n "$GRADLE_FILES" ]; then
     echo "Running spotlessKotlinGradleCheck..."
     ./gradlew spotlessKotlinGradleCheck
     if [ $? -ne 0 ]; then
-        echo "❌ Gradle files need formatting. Please run './gradlew spotlessKotlinGradleApply' and commit again."
+        echo "❌ Gradle files need formatting. Please run './gradlew spotlessKotlinGradleApply' or 'make format' and commit again."
         exit 1
     fi
 fi
@@ -28,7 +28,7 @@ if [ -n "$CPP_FILES" ]; then
     echo "Running spotlessCppCheck..."
     ./gradlew spotlessCppCheck
     if [ $? -ne 0 ]; then
-        echo "❌ C++ files need formatting. Please run './gradlew spotlessCppApply' and commit again."
+        echo "❌ C++ files need formatting. Please run './gradlew spotlessCppApply' or 'make format' and commit again."
         exit 1
     fi
 fi 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,23 +1,66 @@
 #!/bin/sh
 
 # Get list of files that are staged for commit
-FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(android/.*\.kt|.*\.gradle\.kts|jni/.*\.(cpp|h|c|hpp|cc)|cli/.*\.(cpp|h|c|hpp|cc)|cpp/.*\.(cpp|h|c|hpp|cc))$' || true)
+KT_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^android/.*\.kt$' || true)
+GRADLE_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '.*\.gradle\.kts$' || true)
+CPP_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(jni/.*\.(cpp|h|c|hpp|cc)|cli/.*\.(cpp|h|c|hpp|cc)|cpp/.*\.(cpp|h|c|hpp|cc))$' || true)
 
-# Only run spotlessApply if there are matching files
-if [ -n "$FILES" ]; then
-    echo "Running spotlessApply for matching files..."
+# Run spotlessKotlinApply if there are Kotlin files
+if [ -n "$KT_FILES" ]; then
+    echo "Running spotlessKotlinApply for Kotlin files..."
     echo "Files to be formatted:"
-    echo "$FILES"
-    ./gradlew spotlessApply
+    echo "$KT_FILES"
+    ./gradlew spotlessKotlinApply
 
-    # Check if spotlessApply was successful
+    # Check if spotlessKotlinApply was successful
     if [ $? -ne 0 ]; then
-        echo "❌ spotlessApply failed. Please fix the formatting issues and try again."
+        echo "❌ spotlessKotlinApply failed. Please fix the formatting issues and try again."
         exit 1
     fi
+fi
 
-    # Add the changes made by spotlessApply
-    git add .
+# Run spotlessKotlinGradleApply if there are Gradle files
+if [ -n "$GRADLE_FILES" ]; then
+    echo "Running spotlessKotlinGradleApply for Gradle files..."
+    echo "Files to be formatted:"
+    echo "$GRADLE_FILES"
+    ./gradlew spotlessKotlinGradleApply
 
-    echo "✅ spotlessApply completed successfully"
+    # Check if spotlessKotlinGradleApply was successful
+    if [ $? -ne 0 ]; then
+        echo "❌ spotlessKotlinGradleApply failed. Please fix the formatting issues and try again."
+        exit 1
+    fi
+fi
+
+# Run spotlessCppApply if there are C++ files
+if [ -n "$CPP_FILES" ]; then
+    echo "Running spotlessCppApply for C++ files..."
+    echo "Files to be formatted:"
+    echo "$CPP_FILES"
+    ./gradlew spotlessCppApply
+
+    # Check if spotlessCppApply was successful
+    if [ $? -ne 0 ]; then
+        echo "❌ spotlessCppApply failed. Please fix the formatting issues and try again."
+        exit 1
+    fi
+fi
+
+# Refresh staged state after spotless runs
+git add .
+
+# Check if there are any staged files after spotless
+if [ -n "$KT_FILES" ] || [ -n "$GRADLE_FILES" ] || [ -n "$CPP_FILES" ]; then
+    # Get all files that are still staged
+    STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR)
+    
+    if [ -z "$STAGED_FILES" ]; then
+        echo "All changes were reverted by formatting. Aborting commit."
+        exit 1
+    fi
+    
+    echo "Files still staged after formatting:"
+    echo "$STAGED_FILES"
+    echo "✅ Formatting completed successfully"
 fi 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,62 +5,30 @@ KT_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^android/
 GRADLE_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '.*\.gradle\.kts$' || true)
 CPP_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(jni/.*\.(cpp|h|c|hpp|cc)|cli/.*\.(cpp|h|c|hpp|cc)|cpp/.*\.(cpp|h|c|hpp|cc))$' || true)
 
-# Run spotlessKotlinApply if there are Kotlin files
+# Run spotless checks if needed
 if [ -n "$KT_FILES" ]; then
-    echo "Running spotlessKotlinApply for Kotlin files..."
-    echo "Files to be formatted:"
-    echo "$KT_FILES"
-    ./gradlew spotlessKotlinApply
-
-    # Check if spotlessKotlinApply was successful
+    echo "Running spotlessKotlinCheck..."
+    ./gradlew spotlessKotlinCheck
     if [ $? -ne 0 ]; then
-        echo "❌ spotlessKotlinApply failed. Please fix the formatting issues and try again."
+        echo "❌ Kotlin files need formatting. Please run './gradlew spotlessKotlinApply' and commit again."
         exit 1
     fi
 fi
 
-# Run spotlessKotlinGradleApply if there are Gradle files
 if [ -n "$GRADLE_FILES" ]; then
-    echo "Running spotlessKotlinGradleApply for Gradle files..."
-    echo "Files to be formatted:"
-    echo "$GRADLE_FILES"
-    ./gradlew spotlessKotlinGradleApply
-
-    # Check if spotlessKotlinGradleApply was successful
+    echo "Running spotlessKotlinGradleCheck..."
+    ./gradlew spotlessKotlinGradleCheck
     if [ $? -ne 0 ]; then
-        echo "❌ spotlessKotlinGradleApply failed. Please fix the formatting issues and try again."
+        echo "❌ Gradle files need formatting. Please run './gradlew spotlessKotlinGradleApply' and commit again."
         exit 1
     fi
 fi
 
-# Run spotlessCppApply if there are C++ files
 if [ -n "$CPP_FILES" ]; then
-    echo "Running spotlessCppApply for C++ files..."
-    echo "Files to be formatted:"
-    echo "$CPP_FILES"
-    ./gradlew spotlessCppApply
-
-    # Check if spotlessCppApply was successful
+    echo "Running spotlessCppCheck..."
+    ./gradlew spotlessCppCheck
     if [ $? -ne 0 ]; then
-        echo "❌ spotlessCppApply failed. Please fix the formatting issues and try again."
+        echo "❌ C++ files need formatting. Please run './gradlew spotlessCppApply' and commit again."
         exit 1
     fi
-fi
-
-# Refresh staged state after spotless runs
-git add .
-
-# Check if there are any staged files after spotless
-if [ -n "$KT_FILES" ] || [ -n "$GRADLE_FILES" ] || [ -n "$CPP_FILES" ]; then
-    # Get all files that are still staged
-    STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR)
-    
-    if [ -z "$STAGED_FILES" ]; then
-        echo "All changes were reverted by formatting. Aborting commit."
-        exit 1
-    fi
-    
-    echo "Files still staged after formatting:"
-    echo "$STAGED_FILES"
-    echo "✅ Formatting completed successfully"
 fi 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,16 +1,23 @@
 #!/bin/sh
 
-echo "Running spotlessApply..."
-./gradlew spotlessApply
+# Get list of files that are staged for commit
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(android/.*\.kt|.*\.gradle\.kts|jni/.*\.(cpp|h|c|hpp|cc)|cli/.*\.(cpp|h|c|hpp|cc)|cpp/.*\.(cpp|h|c|hpp|cc))$' || true)
 
-# Check if spotlessApply was successful
-if [ $? -ne 0 ]; then
-    echo "❌ spotlessApply failed. Please fix the formatting issues and try again."
-    exit 1
-fi
+# Only run spotlessApply if there are matching files
+if [ -n "$FILES" ]; then
+    echo "Running spotlessApply for matching files..."
+    echo "Files to be formatted:"
+    echo "$FILES"
+    ./gradlew spotlessApply
 
-# Add the changes made by spotlessApply
-git add .
+    # Check if spotlessApply was successful
+    if [ $? -ne 0 ]; then
+        echo "❌ spotlessApply failed. Please fix the formatting issues and try again."
+        exit 1
+    fi
 
-echo "✅ spotlessApply completed successfully"
-exit 0 
+    # Add the changes made by spotlessApply
+    git add .
+
+    echo "✅ spotlessApply completed successfully"
+fi 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "Running spotlessApply..."
+./gradlew spotlessApply
+
+# Check if spotlessApply was successful
+if [ $? -ne 0 ]; then
+    echo "❌ spotlessApply failed. Please fix the formatting issues and try again."
+    exit 1
+fi
+
+# Add the changes made by spotlessApply
+git add .
+
+echo "✅ spotlessApply completed successfully"
+exit 0 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  build:
+  spotless-detekt-unittests:
     runs-on: ubuntu-latest
 
     steps:
@@ -64,4 +64,4 @@ jobs:
           if [ $? -ne 0 ]; then
             echo "❌ Unit tests failed. Please fix the failing tests locally."
             exit 1
-          fi
+          fi 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,15 +27,16 @@ jobs:
           path: /usr/local/clang-20.1.5
           key: clang-format-20.1.5
           
-      - name: Install clang-format 20.1.5
+      - name: Install clang-format 20.1.5 (via apt.llvm.org)
         run: |
           sudo apt update
-          sudo apt install -y wget gnupg
+          sudo apt install -y wget gnupg software-properties-common
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 20
-          sudo ln -sf /usr/bin/clang-format-20 /usr/bin/clang-format
-          clang-format --version  # optional sanity check
+          sudo apt install -y clang-format-20
+          sudo ln -sf /usr/bin/clang-format-20 /usr/local/bin/clang-format
+          clang-format --version
           
       - name: Verify clang-format installation
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,13 +28,14 @@ jobs:
           key: clang-format-20.1.5
           
       - name: Install clang-format 20.1.5
-        if: steps.clang-cache.outputs.cache-hit != 'true'
         run: |
-          echo "Installing clang-format 20.1.5..."
-          wget https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.5/clang+llvm-20.1.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
-          tar xf clang+llvm-20.1.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
-          sudo mv clang+llvm-20.1.5-x86_64-linux-gnu-ubuntu-22.04 /usr/local/clang-20.1.5
-          echo "/usr/local/clang-20.1.5/bin" >> $GITHUB_PATH
+          sudo apt update
+          sudo apt install -y wget gnupg
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
+          sudo ln -sf /usr/bin/clang-format-20 /usr/bin/clang-format
+          clang-format --version  # optional sanity check
           
       - name: Verify clang-format installation
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,15 +21,11 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Install clang-format 11 (via apt.llvm.org)
+      - name: Install clang-format 14 (native)
         run: |
           sudo apt update
-          sudo apt install -y wget gnupg software-properties-common
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 11
-          sudo apt install -y clang-format-11
-          sudo ln -sf /usr/bin/clang-format-11 /usr/local/bin/clang-format
+          sudo apt install -y clang-format-14
+          sudo ln -sf /usr/bin/clang-format-14 /usr/local/bin/clang-format
           clang-format --version
 
       - name: Verify clang-format installation

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,9 +10,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -20,16 +21,28 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Install clang-format 11
+      - name: Install clang-format 11 (via apt.llvm.org)
         run: |
           sudo apt update
+          sudo apt install -y wget gnupg software-properties-common
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 11
           sudo apt install -y clang-format-11
           sudo ln -sf /usr/bin/clang-format-11 /usr/local/bin/clang-format
           clang-format --version
 
+      - name: Verify clang-format installation
+        run: |
+          if ! command -v clang-format >/dev/null; then
+            echo "❌ clang-format not found"
+            exit 1
+          fi
+          clang-format --version
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-        
+
       - name: Run spotlessCheck
         run: |
           echo "Running spotlessCheck..."
@@ -38,7 +51,7 @@ jobs:
             echo "❌ spotlessCheck failed. Please run './gradlew spotlessApply' locally to fix formatting issues."
             exit 1
           fi
-        
+
       - name: Run detekt
         run: |
           echo "Running detekt..."

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,33 +19,14 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
-          
-      - name: Cache clang-format
-        uses: actions/cache@v3
-        id: clang-cache
-        with:
-          path: /usr/local/clang-20.1.5
-          key: clang-format-20.1.5
-          
-      - name: Install clang-format 20.1.5 (via apt.llvm.org)
+
+      - name: Install clang-format 11
         run: |
           sudo apt update
-          sudo apt install -y wget gnupg software-properties-common
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 20
-          sudo apt install -y clang-format-20
-          sudo ln -sf /usr/bin/clang-format-20 /usr/local/bin/clang-format
+          sudo apt install -y clang-format-11
+          sudo ln -sf /usr/bin/clang-format-11 /usr/local/bin/clang-format
           clang-format --version
-          
-      - name: Verify clang-format installation
-        run: |
-          clang-format --version
-          if [ $? -ne 0 ]; then
-            echo "❌ clang-format installation failed"
-            exit 1
-          fi
-          
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
         
@@ -66,7 +47,7 @@ jobs:
             echo "❌ detekt found code style issues. Please fix them locally."
             exit 1
           fi
-        
+
       - name: Run unit tests
         run: |
           echo "Running unit tests..."
@@ -74,4 +55,4 @@ jobs:
           if [ $? -ne 0 ]; then
             echo "❌ Unit tests failed. Please fix the failing tests locally."
             exit 1
-          fi 
+          fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,9 +8,8 @@ on:
       - main
 
 jobs:
-  spotless-detekt-unittests:
+  check-format:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +46,21 @@ jobs:
             echo "❌ spotlessCheck failed. Please run './gradlew spotlessApply' locally to fix formatting issues."
             exit 1
           fi
+
+  build-test-kotlin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
       - name: Run detekt
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,75 @@
+name: PR Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+          
+      - name: Cache clang-format
+        uses: actions/cache@v3
+        id: clang-cache
+        with:
+          path: /usr/local/clang-20.1.5
+          key: clang-format-20.1.5
+          
+      - name: Install clang-format 20.1.5
+        if: steps.clang-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Installing clang-format 20.1.5..."
+          wget https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.5/clang+llvm-20.1.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+          tar xf clang+llvm-20.1.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+          sudo mv clang+llvm-20.1.5-x86_64-linux-gnu-ubuntu-22.04 /usr/local/clang-20.1.5
+          echo "/usr/local/clang-20.1.5/bin" >> $GITHUB_PATH
+          
+      - name: Verify clang-format installation
+        run: |
+          clang-format --version
+          if [ $? -ne 0 ]; then
+            echo "❌ clang-format installation failed"
+            exit 1
+          fi
+          
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+        
+      - name: Run spotlessCheck
+        run: |
+          echo "Running spotlessCheck..."
+          ./gradlew spotlessCheck
+          if [ $? -ne 0 ]; then
+            echo "❌ spotlessCheck failed. Please run './gradlew spotlessApply' locally to fix formatting issues."
+            exit 1
+          fi
+        
+      - name: Run detekt
+        run: |
+          echo "Running detekt..."
+          ./gradlew detekt
+          if [ $? -ne 0 ]; then
+            echo "❌ detekt found code style issues. Please fix them locally."
+            exit 1
+          fi
+        
+      - name: Run unit tests
+        run: |
+          echo "Running unit tests..."
+          ./gradlew testDebugUnitTest
+          if [ $? -ne 0 ]; then
+            echo "❌ Unit tests failed. Please fix the failing tests locally."
+            exit 1
+          fi 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,32 @@ With `all` option, it will conduct deep clean including open source components.
 
 WhisperKit Android is currently in the beta stage. We are actively developing the project and welcome contributions from the community.
 
+## Git Hooks
+
+This project uses Git hooks to maintain code quality. These hooks help ensure consistent code formatting and quality standards.
+
+### Setup
+
+To use the Git hooks, run the following command in your repository root:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+### Available Hooks
+
+#### pre-commit
+- Runs `spotlessApply` to automatically fix code formatting issues
+- If formatting fixes are applied, they are automatically staged
+- The commit will be blocked if `spotlessApply` fails
+
+### Troubleshooting
+
+If you need to bypass the hooks temporarily (not recommended), you can use:
+```bash
+git commit --no-verify
+```
+
 # License
 
 - We release WhisperKit Android under [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -230,6 +230,38 @@ With `all` option, it will conduct deep clean including open source components.
 
 WhisperKit Android is currently in the beta stage. We are actively developing the project and welcome contributions from the community.
 
+## Development Setup
+
+### Installing clang-format
+
+The project uses clang-format 14 for C++ code formatting. You'll need to install it based on your operating system:
+
+#### macOS
+```bash
+# Install LLVM 14
+brew install llvm@14
+
+# Create symlink for clang-format
+sudo ln -sf /opt/homebrew/opt/llvm@14/bin/clang-format /opt/homebrew/bin/clang-format
+```
+
+#### Linux (Ubuntu/Debian)
+```bash
+sudo apt update
+sudo apt install -y clang-format-14
+sudo ln -sf /usr/bin/clang-format-14 /usr/local/bin/clang-format
+```
+
+Verify the installation:
+```bash
+clang-format --version
+```
+
+To check C++ code formatting:
+```bash
+./gradlew spotlessCppCheck
+```
+
 ## Git Hooks
 
 This project uses Git hooks to maintain code quality. These hooks help ensure consistent code formatting and quality standards.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,6 @@ spotless {
             "cpp/**/*.cpp", "cpp/**/*.h", "cpp/**/*.c", "cpp/**/*.hpp", "cpp/**/*.cc",
         )
         targetExclude("**/build/**", "**/external/**")
-        clangFormat("11.1.0")
+        clangFormat("14.0.6")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,6 @@ spotless {
             "cpp/**/*.cpp", "cpp/**/*.h", "cpp/**/*.c", "cpp/**/*.hpp", "cpp/**/*.cc",
         )
         targetExclude("**/build/**", "**/external/**")
-        clangFormat("20.1.5")
+        clangFormat("11.1.0")
     }
 }

--- a/cpp/src/Models/TextDecoder.cpp
+++ b/cpp/src/Models/TextDecoder.cpp
@@ -101,15 +101,15 @@ bool is_exact_match_for_separate_kv_cache_no_alignment_heads(const tflite::Model
     }
 
     /* helper functions to calculate the number of inputs and outputs for a given number of layers */
-    auto calculate_num_inputs_for_variant_with_layers = [=](const int num_layers) -> auto {
+    auto calculate_num_inputs_for_variant_with_layers = [=](const int num_layers) -> auto{
         return num_shared_inputs + num_layers * kv_factor;
     };
 
-    auto calculate_num_outputs_for_variant_with_layers = [=](const int num_layers) -> auto {
+    auto calculate_num_outputs_for_variant_with_layers = [=](const int num_layers) -> auto{
         return kv_factor * num_layers + 1;
     };
 
-    auto output_names_for_variant_with_layers = [=](const int num_layers) -> auto {
+    auto output_names_for_variant_with_layers = [=](const int num_layers) -> auto{
         std::unordered_set<std::string> output_names;
         output_names.insert(std::string("logits"));
         for (int i = 0; i < num_layers; ++i) {
@@ -119,7 +119,7 @@ bool is_exact_match_for_separate_kv_cache_no_alignment_heads(const tflite::Model
         return output_names;
     };
 
-    auto input_names_for_variant_with_layers = [](const int num_layers) -> auto {
+    auto input_names_for_variant_with_layers = [](const int num_layers) -> auto{
         std::unordered_set<std::string> input_names;
         input_names.insert(std::string("x"));
         input_names.insert(std::string("index"));

--- a/cpp/src/Text/post_proc.cpp
+++ b/cpp/src/Text/post_proc.cpp
@@ -5,7 +5,7 @@
 #define LOGITS_TO_NEG_INF(start, end) \
     for (auto iter = (start); iter != (end); iter++) *iter = -1e9;
 
-#define DEC_2_ROUND(x) (round((x) * 100.0) / 100.0)
+#define DEC_2_ROUND(x) (round((x)*100.0) / 100.0)
 
 using namespace std;
 using json = nlohmann::json;

--- a/cpp/src/Text/post_proc.hpp
+++ b/cpp/src/Text/post_proc.hpp
@@ -14,7 +14,7 @@ constexpr const uint32_t SAMPLE_BEGIN = 1;
 class PostProcModel : public MODEL_SUPER_CLASS {
    public:
     PostProcModel(Tokenizer* tokenizer, bool timestamp_text = false);
-    virtual ~PostProcModel() {};
+    virtual ~PostProcModel(){};
 
     bool initialize(bool debug = false);
     virtual void invoke(bool measure_time = false);

--- a/cpp/src/WhisperKitConfiguration.cpp
+++ b/cpp/src/WhisperKitConfiguration.cpp
@@ -4,7 +4,7 @@
 #include "WhisperKitPipeline.hpp"
 #include "backend_class.hpp"
 
-whisperkit_configuration_t::whisperkit_configuration_t() {};
+whisperkit_configuration_t::whisperkit_configuration_t(){};
 
 void whisperkit_configuration_t::set_audio_encoder(const char* audio_encoder) noexcept {
     this->audio_encoder = audio_encoder;


### PR DESCRIPTION
## Description  
* Add github action `check-format` and `build-test-kotlin` to run spotless, detekt and android unit tests on PRs
* Update spotless to use clang-format 14 - it has a stable version on both mac and ubuntu, making it possible to work on local and remote env. Also apply the fix on newly added c files
* Update a git precommit hook to apply spotless formatter for 3 sets of files: `kt`, `gradle` and `cpp`, if no files were changed after reformatting abort the commit
* update readme to configure precommit hook and clang-format
## Type of Change  
- [ ] Bug fix 🐛  
- [x] New feature 🚀  
- [ ] Refactor 🔄  
- [ ] Documentation update 📖  
- [ ] Other (please describe)  

## Test Plan  
- [ ] I have run `bash test/test_build_all.sh` and it ran successfully
- [ ] I have tested this change on all relevant platforms.  

## Checklist  
- [ ] My code follows the project's style guidelines.  
- [ ] I have updated relevant documentation (if applicable).  
- [ ] I have added appropriate tests (if applicable).  
- [x] I have self-reviewed my code before requesting review.  
