### PR TITLE
Fix tokenizers-sys to use HTTPS like other git clones

### DIFF
--- a/scripts/dev_env.sh
+++ b/scripts/dev_env.sh
@@ -67,7 +67,7 @@ if ! $(docker image inspect $IMAGE_NAME > /dev/null 2>&1) || $FORCE_REBUILD; the
   fi
   if [ ! -d "$BUILD_DIR/tokenizers-sys" ]; then
     echo "Cloning tokenizers-sys..."
-    git clone git@github.com:FL33TW00D/tokenizers-sys.git $BUILD_DIR/tokenizers-sys
+    git clone https://github.com/FL33TW00D/tokenizers-sys.git $BUILD_DIR/tokenizers-sys
     cd $BUILD_DIR/tokenizers-sys
     git checkout 686f9341517ecac0d4afcdf48e4863242a3d3cde
     cd -


### PR DESCRIPTION
## Description  
For some reason the build script use SSH to clone the `tokenizers-sys` repo, whereas all other clones use HTTPS. This will break on environments where SSH is not configured. Switch to HTTPS to match the other repos.

## Type of Change  
- [x] Bug fix 🐛  
- [ ] New feature 🚀  
- [ ] Refactor 🔄  
- [ ] Documentation update 📖  
- [ ] Other (please describe)  

## Test Plan  
- [ ] I have run `bash test/test_build_all.sh` and it ran successfully
- [ ] I have tested this change on all relevant platforms.  

## Checklist  
- [ ] My code follows the project's style guidelines.  
- [ ] I have updated relevant documentation (if applicable).  
- [ ] I have added appropriate tests (if applicable).  
- [ ] I have self-reviewed my code before requesting review.  
